### PR TITLE
Add _meta to ToolResponse output

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/mark3labs/mcp-go
 
-go 1.23
+go 1.23.0
 
 require (
 	github.com/google/uuid v1.6.0

--- a/mcp/tools.go
+++ b/mcp/tools.go
@@ -613,6 +613,11 @@ func (t Tool) MarshalJSON() ([]byte, error) {
 
 	m["annotations"] = t.Annotations
 
+	// Marshal Meta if present
+	if t.Meta != nil {
+		m["_meta"] = t.Meta
+	}
+
 	return json.Marshal(m)
 }
 


### PR DESCRIPTION
## Summary:
Needed for openai ui integration. Looks like it was missed as an oversight in the current implementation.

Issue: none

## Test plan:
I've used this in our mcp-gateway service, and the _meta information is correctly transmitted.